### PR TITLE
Add munit-cats-effect 2.0 working example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,5 +6,6 @@ ThisBuild / organizationName := "example"
 lazy val root = (project in file("."))
   .settings(
     name := "munit-suite-fixture-bug",
-    libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
+    libraryDependencies += "org.scalameta" %% "munit" % "1.0.0-M5" % Test,
+    libraryDependencies += "org.typelevel" %% "munit-cats-effect" % "2.0-cd8357d-SNAPSHOT" % Test
   )

--- a/src/test/scala/example/HelloCatsEffectSuite.scala
+++ b/src/test/scala/example/HelloCatsEffectSuite.scala
@@ -1,0 +1,27 @@
+package example
+
+import org.junit.experimental.categories.Category
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import example.Slow
+import cats.effect.kernel.Resource
+
+
+@Category(Array(classOf[Slow]))
+class MyCatsEffectSuite extends CatsEffectSuite {
+
+  val resourceFixture = ResourceSuiteLocalFixture(
+    "my-resource-suite-local-fixture",
+    Resource.make(IO.println("### resource fixture acquired ###"))(_ => IO.println("### resource fixture released ###"))
+  )
+  override def munitFixtures = List(resourceFixture)
+
+  test("test1") {
+    IO(resourceFixture()).assertEquals(())
+  }
+
+  test("test2") {
+    IO(resourceFixture()).assertEquals(())
+  }
+}


### PR DESCRIPTION
I've published https://github.com/typelevel/munit-cats-effect/pull/223 locally and tested that filtering suite level resource fixtures works as expected.

Running `test` in sbt yields the expected:

```
test                                                                              [40/129]
[info] compiling 1 Scala source to /Users/valencik/projects/munit-fixture-suite-filtering/target/scala-2.13/test-classe
s ...                                                      
### beforeAll is running ###                               
### myFixture apply() ###
### myFixture apply() ###
### afterAll is running ###                                                                                            
example.MySuite:
  + test1 0.016s
  + test2 0.001s
### resource fixture acquired ###
### resource fixture released ###
example.MyCatsEffectSuite:
  + test1 0.005s                                           
  + test2 0.004s
[info] Passed: Total 4, Failed 0, Errors 0, Passed 4  
```

And running `testOnly -- --exclude-categories=example.Slow` correctly excludes all tests and does not run their fixtures!

```
example.MySuite:                                           
example.MyCatsEffectSuite:                                                                                             
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0                                                                   
[success] Total time: 0 s, completed Jun. 25, 2022, 10:20:16 a.m.
```